### PR TITLE
Update swift starter app to receive badge notifications

### DIFF
--- a/NotifySwiftQuickstart/AppDelegate.swift
+++ b/NotifySwiftQuickstart/AppDelegate.swift
@@ -21,11 +21,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // Override point for customization after application launch.
     if #available(iOS 10, *) {
         let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert], completionHandler: { (granted, error) in
+        center.requestAuthorization(options: [.alert, .badge, .sound], completionHandler: { (granted, error) in
             UIApplication.shared.registerForRemoteNotifications()
         })
     } else {
-        let settings = UIUserNotificationSettings(types: .alert, categories: nil)
+        let settings = UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
         UIApplication.shared.registerUserNotificationSettings(settings)
         UIApplication.shared.registerForRemoteNotifications()
     }


### PR DESCRIPTION
Update swift code as required by [DEVED-2345](https://issues.corp.twilio.com/browse/DEVED-2345) to enable badge notifications.