### PR TITLE
Fixed the way notifications are displayed

### DIFF
--- a/NotifySwiftQuickstart/AppDelegate.swift
+++ b/NotifySwiftQuickstart/AppDelegate.swift
@@ -85,8 +85,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
     print("Message received.")
     if let aps = userInfo[AnyHashable("aps")] as? [AnyHashable: Any] {
-        let message = aps[AnyHashable("alert")] as? String
-        let alertController = UIAlertController(title: "Notification", message: message, preferredStyle: .alert)
+        let alert = aps[AnyHashable("alert")] as! NSDictionary
+        let body = alert["body"] as? String
+        let title = alert["title"] as? String
+        let alertController = UIAlertController(title: title, message: body, preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         alertController.addAction(defaultAction)
         self.window?.rootViewController?.present(alertController, animated: true, completion: nil)

--- a/NotifySwiftQuickstart/AppDelegate.swift
+++ b/NotifySwiftQuickstart/AppDelegate.swift
@@ -85,9 +85,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any]) {
     print("Message received.")
     if let aps = userInfo[AnyHashable("aps")] as? [AnyHashable: Any] {
-        let alert = aps[AnyHashable("alert")] as! NSDictionary
-        let body = alert["body"] as? String
-        let title = alert["title"] as? String
+        let alert = aps[AnyHashable("alert")] != nil ? aps[AnyHashable("alert")] as! NSDictionary : [:] as NSDictionary
+        let body  = alert["body"]  != nil ? alert["body"]  as! String : ""
+        let title = alert["title"] != nil ? alert["title"] as! String : "Notification"
         let alertController = UIAlertController(title: title, message: body, preferredStyle: .alert)
         let defaultAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         alertController.addAction(defaultAction)
@@ -95,4 +95,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
   }
 }
+
 


### PR DESCRIPTION
When application is in foreground, the notification is displayed with empty body and default title "Notification".

This sets both the title and the body to the values from the push notification.